### PR TITLE
check_install.py can check versions in python3 as well

### DIFF
--- a/check_install.py
+++ b/check_install.py
@@ -4,16 +4,18 @@ Using Geospatial Data With Python
 
 """
 
+from __future__ import print_function
 import sys
-print 'Using python in', sys.prefix
-print sys.version
+print('Using python in', sys.prefix)
+print(sys.version)
 
 def import_version(pkg):
     try:
-        exec('from %s import __version__' % pkg)
-        print OK, '%s version %s' % (pkg, __version__)
+        var_dict = {}
+        exec('from %s import __version__' % pkg, None, var_dict)
+        print(OK, '%s version %s' % (pkg, var_dict['__version__']))
     except ImportError:
-        print FAIL, '%s not installed' % pkg
+        print(FAIL, '%s not installed' % pkg)
 
 try:
     import curses
@@ -25,8 +27,8 @@ except:
     OK = '[ OK ]'
     FAIL = '[FAIL]'
 
-print
-print 'Required packages:'
+print()
+print('Required packages:')
 
 import_version('shapely')
 import_version('fiona')
@@ -34,26 +36,26 @@ import_version('pyproj')
 
 try:
     import osgeo.gdal
-    print OK, 'GDAL version', osgeo.gdal.__version__
+    print(OK, 'GDAL version', osgeo.gdal.__version__)
 except:
-    print FAIL, 'GDAL not installed'
+    print(FAIL, 'GDAL not installed')
 
 try:
     from mpl_toolkits.basemap import __version__
-    print OK, 'Basemap version', __version__
+    print(OK, 'Basemap version', __version__)
 except ImportError:
-    print FAIL, 'Basemap not installed'
+    print(FAIL, 'Basemap not installed')
 
 
-print
-print 'Optional packages:'
+print()
+print('Optional packages:')
 
 try:
     import geojson
 except ImportError:
-    print FAIL, 'geoJSON not installed'
+    print(FAIL, 'geoJSON not installed')
 else:
-    print OK, 'geoJSON is installed'
+    print(OK, 'geoJSON is installed')
 
 import_version('cartopy')
 import_version('psycopg2')


### PR DESCRIPTION
I have updated check_install.py. Now it can check versions in python3 as well if you run it with python3. I have checked it works with 2.7.6 as well.
