### PR TITLE
Make citibike.py work in Python v3

### DIFF
--- a/examples/citibike.py
+++ b/examples/citibike.py
@@ -45,7 +45,7 @@ nyp = Proj('+datum=NAD83 +lat_0=40.1666666667 +lat_1=40.6666666667 '
            '+x_0=300000 +y_0', preserve_units=True)
 wgs84 = Proj(init='epsg:4326')
 x, y = transform(wgs84, nyp, lon, lat)
-points = MultiPoint(zip(x, y))
+points = MultiPoint(list(zip(x, y)))
 points = MultiPoint([p for p in points.geoms if manhattan.contains(p)])
 pt_arr = np.asarray(points)
 


### PR DESCRIPTION
zip() returns an iterator in Python 3. Wrapping the iterator in list() returns the zipped list, and does not change the zipped list in Python 2,
